### PR TITLE
[Fix] Material3 overlay로 PopupMenu 배경 색상이 변하던 문제 수정

### DIFF
--- a/app/src/main/java/com/example/dogcatsquare/ui/community/LocalPostAdapter.kt
+++ b/app/src/main/java/com/example/dogcatsquare/ui/community/LocalPostAdapter.kt
@@ -2,6 +2,7 @@ package com.example.dogcatsquare.ui.community
 
 import android.content.Context
 import android.text.TextUtils
+import android.view.Gravity
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
@@ -112,7 +113,7 @@ class LocalPostAdapter(
         post: LocalPost,
         position: Int
     ) {
-        val popup = PopupMenu(context, view)
+        val popup = PopupMenu(context, view, Gravity.END, 0, R.style.MyPopupMenu)
         popup.menuInflater.inflate(R.menu.post_menu, popup.menu)
         popup.setOnMenuItemClickListener { item ->
             when (item.itemId) {

--- a/app/src/main/java/com/example/dogcatsquare/ui/mypage/MyReviewRVAdapter.kt
+++ b/app/src/main/java/com/example/dogcatsquare/ui/mypage/MyReviewRVAdapter.kt
@@ -21,7 +21,8 @@ import retrofit2.Response
 
 class MyReviewRVAdapter(private val myReviewList: ArrayList<ReviewContent>, private val onDeleteReview: (DeleteReviewParams) -> Unit) : RecyclerView.Adapter<MyReviewRVAdapter.MyReviewAdapterViewHolder>() {
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): MyReviewAdapterViewHolder {
-        val binding = ItemMyReviewBinding.inflate(LayoutInflater.from(parent.context), parent, false)
+        val binding =
+            ItemMyReviewBinding.inflate(LayoutInflater.from(parent.context), parent, false)
         return MyReviewAdapterViewHolder(binding)
     }
 
@@ -32,7 +33,8 @@ class MyReviewRVAdapter(private val myReviewList: ArrayList<ReviewContent>, priv
 
     override fun getItemCount(): Int = myReviewList.size
 
-    inner class MyReviewAdapterViewHolder(val binding: ItemMyReviewBinding) : RecyclerView.ViewHolder(binding.root) {
+    inner class MyReviewAdapterViewHolder(val binding: ItemMyReviewBinding) :
+        RecyclerView.ViewHolder(binding.root) {
         fun bind(myReview: ReviewContent) {
             binding.placeName.text = myReview.title
             binding.reviewText.text = myReview.content
@@ -44,13 +46,25 @@ class MyReviewRVAdapter(private val myReviewList: ArrayList<ReviewContent>, priv
 
             // 설정 클릭(수정, 삭제)
             binding.settingIv.setOnClickListener {
-                showPopupMenu(it, itemView.context, myReview.id, myReview.walkId, myReview.googlePlaceId)
+                showPopupMenu(
+                    it,
+                    itemView.context,
+                    myReview.id,
+                    myReview.walkId,
+                    myReview.googlePlaceId
+                )
             }
         }
     }
 
-    private fun showPopupMenu(view: View, myReview: Context, id: Int, walkId: Int?, googlePlaceId: String?) {
-        val popup = PopupMenu(myReview, view)
+    private fun showPopupMenu(
+        view: View,
+        myReview: Context,
+        id: Int,
+        walkId: Int?,
+        googlePlaceId: String?
+    ) {
+        val popup = PopupMenu(myReview, view, android.view.Gravity.END, 0, R.style.CustomPopupStyle)
         popup.menuInflater.inflate(R.menu.review_menu, popup.menu)
         popup.setOnMenuItemClickListener { item ->
             when (item.itemId) {
@@ -58,6 +72,7 @@ class MyReviewRVAdapter(private val myReviewList: ArrayList<ReviewContent>, priv
                     onDeleteReview(DeleteReviewParams(id, googlePlaceId, walkId))
                     true
                 }
+
                 else -> false
             }
         }

--- a/app/src/main/res/drawable/popup_white_bg.xml
+++ b/app/src/main/res/drawable/popup_white_bg.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android">
+    <solid android:color="#FFFFFF" />
+    <corners android:radius="16dp" />
+</shape>

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -1,3 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
+<resources>
 
-<resources></resources>
+    <style name="MyPopupMenu" parent="Widget.AppCompat.PopupMenu">
+        <item name="android:popupBackground">@drawable/popup_white_bg</item>
+    </style>
+
+</resources>

--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -9,7 +9,7 @@
     </style>
 
     <style name="CustomPopupStyle" parent="Widget.AppCompat.PopupMenu">
-        <item name="android:popupBackground">@color/white</item>
+        <item name="android:popupBackground">@drawable/popup_white_bg</item>
     </style>
 
     <style name="Theme.DogCatSquare" parent="Base.Theme.DogCatSquare" />


### PR DESCRIPTION
- 테마에 의해 PopupMenu 배경이 tint 되는 현상 발생
- 커스텀 스타일을 적용하여 배경을 drawable로 지정
- 의도한 흰색으로 정상 표시되도록 수정